### PR TITLE
Compute untill requested conditions are satisfied

### DIFF
--- a/src/main/java/nl/tudelft/bep/deeplearning/network/result/csv/ComputeAverageAccuracyFiller.java
+++ b/src/main/java/nl/tudelft/bep/deeplearning/network/result/csv/ComputeAverageAccuracyFiller.java
@@ -1,5 +1,6 @@
 package nl.tudelft.bep.deeplearning.network.result.csv;
 
+import nl.tudelft.bep.deeplearning.network.result.EvaluationFileUtil;
 import nl.tudelft.bep.deeplearning.network.result.ResultUtil;
 import nl.tudelft.bep.deeplearning.network.result.Tester;
 
@@ -24,7 +25,8 @@ public class ComputeAverageAccuracyFiller implements CSVFiller {
 	@Override
 	public String fill(String network, String data, int epochs) {
 		double result = ResultUtil.getAverageAccuracy(network, data, epochs);
-		if (new Double(result).equals(Double.NaN)) {
+		if (new Double(result).equals(Double.NaN)
+				|| EvaluationFileUtil.load(epochs, data, network).size() < this.iterations) {
 			new Tester(network, data).start(this.iterations, epochs);
 			return Double.toString(ResultUtil.getAverageAccuracy(network, data, epochs));
 		}


### PR DESCRIPTION
The filler now computes evaluations until the number of evaluations on the disk equals the amount specified.